### PR TITLE
Update Client.php

### DIFF
--- a/src/Nbobtc/Bitcoind/Client.php
+++ b/src/Nbobtc/Bitcoind/Client.php
@@ -42,9 +42,9 @@ class Client implements ClientInterface
     {
         $ch = curl_init($this->dsn);
 
-        if (null === $params || "" == $params) {
+        if (null === $params || "" === $params) {
             $params = array();
-        } elseif (!empty($params) && !is_array($params)) {
+        } elseif (!is_array($params)) {
             $params = array($params);
         }
 


### PR DESCRIPTION
empty() ignores 0 (for ex. needed for listaccounts unconfirmed balance). there is no need to check emptyness since null is checked before
