### PR TITLE
fix sami not working

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,9 @@
     "require-dev": {
         "phpunit/phpunit": "*",
         "phing/phing": "*",
-        "sami/sami": "*"
+        "sami/sami": "*",
+        "symfony/yaml": ">= 2.1.0 <= 2.6.5",
+        "nikic/php-parser": ">= 1.0.0 <= 1.1.0"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
`sami` is a bit to loose on allowing requirements, as a result it's not working anymore, until issues are fixed in `sami` this fixes the issues for `bitcoind-php`.

 - set symfony/yaml to stay at stable release v2.6.5.
 - set nikic/php-parser to stay at stable release v1.1.0.


