### PR TITLE
Reopen closed cURL resources.

### DIFF
--- a/src/Http/Driver/CurlDriver.php
+++ b/src/Http/Driver/CurlDriver.php
@@ -46,7 +46,7 @@ class CurlDriver implements DriverInterface
     {
         $uri = $request->getUri();
 
-        if (null === self::$ch) {
+        if (null === self::$ch || gettype(self::$ch) != 'curl') {
             self::$ch = curl_init();
         }
 


### PR DESCRIPTION
When a CurlDriver is destroyed, the static cURL resource is closed.  If
CurlDriver is instantiated again in the same request, connections fail.
