### PR TITLE
Avoid curl exception

### DIFF
--- a/src/Http/Driver/CurlDriver.php
+++ b/src/Http/Driver/CurlDriver.php
@@ -34,6 +34,7 @@ class CurlDriver implements DriverInterface
     {
         if (null !== self::$ch) {
             curl_close(self::$ch);
+			self::$ch = null;
         }
     }
 

--- a/src/Http/Driver/CurlDriver.php
+++ b/src/Http/Driver/CurlDriver.php
@@ -34,7 +34,7 @@ class CurlDriver implements DriverInterface
     {
         if (null !== self::$ch) {
             curl_close(self::$ch);
-			self::$ch = null;
+            self::$ch = null;
         }
     }
 

--- a/src/Http/Driver/CurlDriver.php
+++ b/src/Http/Driver/CurlDriver.php
@@ -34,7 +34,7 @@ class CurlDriver implements DriverInterface
     {
         if (null !== self::$ch) {
             curl_close(self::$ch);
-            self::$ch = null;
+            self::$ch = null; // Nulling to avoid calling curl_close again
         }
     }
 


### PR DESCRIPTION
static varible doesn't nulled after usage, so after command execution in php cli we got exception.

> curl_close(): 374 is not a valid cURL handle resource
