### PR TITLE
CurlDriver update #21

### DIFF
--- a/src/Http/Driver/CurlDriver.php
+++ b/src/Http/Driver/CurlDriver.php
@@ -81,6 +81,7 @@ class CurlDriver implements DriverInterface
         $response = $response->withStatus($info['http_code']);
 
         $response->getBody()->write($result);
+        $response->getBody()->rewind(); // empty getContents() without rewind()
 
         return $response;
     }


### PR DESCRIPTION
After updating PSR dependencies getContents() return empty string, to avoid this behavior need use rewind() or seek(0)
