### PR TITLE
Clone body instead of request

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -60,10 +60,9 @@ class Client implements ClientInterface
      * {@inheritdoc}
      */
     public function sendCommand(CommandInterface $command)
-    {
-        $request = clone $this->request;
-
-        $request->getBody()->write(json_encode(
+    {        
+        $body = new \Zend\Diactoros\Stream('php://temp', 'w+');
+        $body->write(json_encode(
             array(
                 'method' => $command->getMethod(),
                 'params' => $command->getParameters(),
@@ -71,6 +70,8 @@ class Client implements ClientInterface
             )
         ));
 
+        $request = $this->request->withBody($body);
+        
         /** @var \Psr\Http\Message\ResponseInterface */
         $this->response = $this->driver->execute($request);
 


### PR DESCRIPTION
On the case when we take multiple requests to the rpc client we need to reset a whole body, not  append json text into it.

In my case I got an error `{"code":-32700,"message":"Parse error"}`