### PR TITLE
Add test: should successfully use two CurlDriver instances

### DIFF
--- a/tests/Http/Driver/CurlDriverTest.php
+++ b/tests/Http/Driver/CurlDriverTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @author Thomas Kerin
+ * @copyright 2017 Thomas Kerin
+ * @license https://github.com/nbobtc/bitcoind-php/blob/2.x/LICENSE MIT
+ */
+
+namespace Tests\Nbobtc\Http\Driver;
+use Nbobtc\Http\Driver\CurlDriver;
+use Psr\Http\Message\ResponseInterface;
+use Zend\Diactoros\Request;
+
+/**
+ */
+class CurlDriverTest extends \PHPUnit_Framework_TestCase
+{
+    public function testExplodesWithTwo() {
+        $body = new \Zend\Diactoros\Stream('php://temp', 'w+');
+        $body->write("test");
+
+        $request = (new Request("https://google.com"));
+        $request = $request->withBody($body);
+
+        $driver = new CurlDriver();
+        /** @var \Psr\Http\Message\ResponseInterface */
+        $response = $driver->execute($request);
+        $this->assertInstanceOf("Psr\Http\Message\ResponseInterface", $response);
+
+        $driver = new CurlDriver();
+        /** @var \Psr\Http\Message\ResponseInterface */
+        $response = $driver->execute($request);
+        $this->assertInstanceOf("Psr\Http\Message\ResponseInterface", $response);
+    }
+}


### PR DESCRIPTION
This when run on 2.0.2 fails because `CurlDriver::$ch` is already closed when the second request runs. Please tag 2.0.3 :)