### PR TITLE
error 500 on failed connection

### DIFF
--- a/src/Http/Driver/CurlDriver.php
+++ b/src/Http/Driver/CurlDriver.php
@@ -73,7 +73,8 @@ class CurlDriver implements DriverInterface
         $error = curl_error(self::$ch);
 
         if (!empty($error)) {
-            throw new \Exception($error);
+            // user can catch the error rather than return error 500 if your bitcoin server went down
+            return new \Exception($error);
         }
 
         $response = new Response();


### PR DESCRIPTION
user can catch the error rather than return error 500 if your bitcoin server went down